### PR TITLE
performance improvelemts & cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yolov7net Now support yolov8 onnx weight file.
 
-.net 6 yolov5,yolov7，yolov8 onnx runtime interface, work for :
+.net 6 yolov5, yolov7, yolov8 onnx runtime interface, work for:
 1. yolov7 https://github.com/WongKinYiu/yolov7
 2. yolov8 https://github.com/ultralytics/ultralytics
 3. yolov5 https://github.com/ultralytics/yolov5

--- a/benchmark/Yolov7netPerformance/Program.cs
+++ b/benchmark/Yolov7netPerformance/Program.cs
@@ -1,7 +1,6 @@
 ﻿// See https://aka.ms/new-console-template for more information
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
-using IVilson.AI.Yolov7net;
 using System.Drawing;
 using Yolov7net;
 
@@ -12,6 +11,7 @@ public class YoloDetector
     private Yolov5 yolov5 = new Yolov5("./assets/yolov7-tiny_640x640.onnx",true);
     private Yolov8 yolov8 = new Yolov8("./assets/yolov8n.onnx", true);
     private Image image = Image.FromFile("Assets/2dog.jpg");
+    
     public YoloDetector()
     {
 
@@ -19,17 +19,23 @@ public class YoloDetector
         yolov8.SetupYoloDefaultLabels();
         yolov5.SetupYoloDefaultLabels();
     }
+
     [Benchmark]
     public void Yolov7()
     {
         var ret = yolov7.Predict(image);
     }
 
-
     [Benchmark]
     public void Yolov8()
     {
         var ret = yolov8.Predict(image);
+    }
+
+    [Benchmark]
+    public void Yolov8Numpy()
+    {
+        var ret = yolov8.Predict(image, useNumpy: true);
     }
 
     [Benchmark]
@@ -47,4 +53,3 @@ public class Program
         Console.ReadLine();
     }
 }
-

--- a/src/Yolov7net/Models/YoloModel.cs
+++ b/src/Yolov7net/Models/YoloModel.cs
@@ -9,15 +9,23 @@ namespace Yolov7net.Models
     public class YoloModel
     {
         public int Width { get; set; }
+
         public int Height { get; set; }
+        
         public int Depth { get; set; }
 
         public int Dimensions { get; set; } //yolov7 包含nms 的模型不需要此参数
+        
         public float Confidence { get; set; } = 0.20f; //yolov7 包含nms 的模型不需要此参数
+        
         public float MulConfidence { get; set; } = 0.25f; //yolov7 包含nms 的模型不需要此参数
+        
         public float Overlap { get; set; } = 0.45f; //yolov7 包含nms 的模型不需要此参数
+        
         public string[] Outputs { get; set; }
+        
         public List<YoloLabel> Labels { get; set; } = new List<YoloLabel>();
+        
         public bool UseDetect { get; set; }
     }
 }

--- a/src/Yolov7net/YoloLabel.cs
+++ b/src/Yolov7net/YoloLabel.cs
@@ -5,8 +5,11 @@ namespace Yolov7net
     public class YoloLabel
     {
         public int Id { get; set; }
+
         public string? Name { get; set; }
+        
         public YoloLabelKind Kind { get; set; }
+        
         public Color Color { get; set; }
 
         public YoloLabel() => Color = Color.Yellow;

--- a/src/Yolov7net/YoloPrediction.cs
+++ b/src/Yolov7net/YoloPrediction.cs
@@ -5,7 +5,9 @@ namespace Yolov7net
     public class YoloPrediction
     {
         public YoloLabel? Label { get; set; }
+
         public RectangleF Rectangle { get; set; }
+        
         public float Score { get; set; }
 
         public YoloPrediction() { }

--- a/test/Yolov7net.test/Yolov7Test.cs
+++ b/test/Yolov7net.test/Yolov7Test.cs
@@ -1,5 +1,4 @@
-
-using IVilson.AI.Yolov7net;
+using System;
 using System.Diagnostics;
 using System.Drawing;
 
@@ -8,45 +7,86 @@ namespace Yolov7net.test
 {
     public class Yolov7Test
     {
+        private readonly (string imageName, string label)[] _testImages = new (string imageName, string label)[]
+        {
+            ("demo.jpg", "dog"),
+            ("cat_224x224.jpg", "cat"),
+        };
+        
         [Fact]
         public void TestYolov7()
         {
-            
             using var yolo = new Yolov7("./assets/yolov7-tiny.onnx", true); //yolov7 模型,不需要 nms 操作
+            
             // setup labels of onnx model 
             yolo.SetupYoloDefaultLabels();   // use custom trained model should use your labels like: yolo.SetupLabels(string[] labels)
             Assert.NotNull(yolo);
-            using var image = Image.FromFile("Assets/demo.jpg");
 
-            var ret = yolo.Predict(image);
-            Assert.NotNull(ret);
-            Assert.True(ret.Count == 1);
+            foreach (var tuple in _testImages)
+            {
+                using var image = Image.FromFile("Assets/" + tuple.imageName);
+                var ret = yolo.Predict(image);
+                CheckResult(ret, tuple.label);
+            }
         }
 
         [Fact]
         public void TestYolov5()
         {
             using var yolo = new Yolov5("./assets/yolov7-tiny_640x640.onnx"); //yolov5 or yolov7 模型, 需要 nms 操作
+            
             // setup labels of onnx model 
             yolo.SetupYoloDefaultLabels();   // use custom trained model should use your labels like: yolo.SetupLabels(string[] labels)
             Assert.NotNull(yolo);
-            using var image = Image.FromFile("Assets/cat_224x224.jpg");
-            var ret = yolo.Predict(image);
-            Assert.NotNull(ret);
-            Assert.True(ret.Count == 1);
+
+            foreach (var tuple in _testImages)
+            {
+                using var image = Image.FromFile("Assets/" + tuple.imageName);
+                var ret = yolo.Predict(image);
+                CheckResult(ret, tuple.label);
+            }
         }
 
         [Fact]
         public void TestYolov8()
         {
             using var yolo = new Yolov8("./assets/yolov8n.onnx"); //yolov8 模型,需要 nms 操作
+            
             // setup labels of onnx model 
             yolo.SetupYoloDefaultLabels();   // use custom trained model should use your labels like: yolo.SetupLabels(string[] labels)
             Assert.NotNull(yolo);
-            using var image = Image.FromFile("Assets/demo.jpg");
-            var ret = yolo.Predict(image,useNumpy:false);
-            Assert.NotNull(ret);
-            Assert.True(ret.Count == 1);
+
+            foreach (var tuple in _testImages)
+            {
+                using var image = Image.FromFile("Assets/" + tuple.imageName);
+                var ret = yolo.Predict(image, useNumpy: false);
+                CheckResult(ret, tuple.label);
+            }
+        }
+
+        [Fact]
+        public void TestYolov8Numpy()
+        {
+            using var yolo = new Yolov8("./assets/yolov8n.onnx"); //yolov8 模型,需要 nms 操作
+
+            // setup labels of onnx model 
+            yolo.SetupYoloDefaultLabels();   // use custom trained model should use your labels like: yolo.SetupLabels(string[] labels)
+            Assert.NotNull(yolo);
+
+            foreach (var tuple in _testImages)
+            {
+                using var image = Image.FromFile("Assets/" + tuple.imageName);
+                var ret = yolo.Predict(image, useNumpy: true);
+                CheckResult(ret, tuple.label);
+            }
+        }
+
+        private void CheckResult(List<YoloPrediction> predictions, string label)
+        {
+            Assert.NotNull(predictions);
+            Assert.Equal(1, predictions.Count);
+            Assert.Equal(label, predictions[0].Label.Name);
+            System.Diagnostics.Debug.WriteLine(predictions[0].Rectangle);
         }
 
         [Fact]
@@ -54,13 +94,14 @@ namespace Yolov7net.test
         {
             using var yolo = new Yolov7("./assets/yolov7-tiny.onnx");
             yolo.SetupYoloDefaultLabels();
-            Stopwatch sw = new Stopwatch();
-            sw.Start();
+            
+            var sw = Stopwatch.StartNew();
             for(int i = 0; i < 10; i++)
             {
                 using var image = Image.FromFile("Assets/demo.jpg");
                 var ret = yolo.Predict(image);
             }
+        
             sw.Stop();
             Debug.WriteLine(sw.ElapsedMilliseconds);
         }


### PR DESCRIPTION
Output parsing is also chagned to use the tensor's Buffer instead of the indexer.
+Some cleanup.

Performance test (with the already existing Yolov7netPerformance project:

Before:
| Method |     Mean |    Error |   StdDev |   Median |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|------- |---------:|---------:|---------:|---------:|----------:|----------:|----------:|----------:|
| Yolov7 | 20.67 ms | 0.230 ms | 0.204 ms | 20.64 ms |  500.0000 |  500.0000 |  500.0000 |      5 MB |
| Yolov8 | 40.55 ms | 2.130 ms | 6.282 ms | 42.57 ms | 9000.0000 | 2000.0000 | 1000.0000 |    103 MB |
| Yolov5 | 20.58 ms | 0.388 ms | 0.399 ms | 20.51 ms |  750.0000 |  562.5000 |  562.5000 |      7 MB |

After:
|      Method |     Mean |    Error |    StdDev |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|------------ |---------:|---------:|----------:|----------:|----------:|----------:|----------:|
|      Yolov7 | 20.23 ms | 0.401 ms |  0.492 ms |  500.0000 |  500.0000 |  500.0000 |      5 MB |
|      Yolov8 | 16.67 ms | 0.333 ms |  0.342 ms |  500.0000 |  500.0000 |  500.0000 |      5 MB |
| Yolov8Numpy | 89.37 ms | 3.732 ms | 10.829 ms | 9000.0000 | 1000.0000 | 1000.0000 |    110 MB |
|      Yolov5 | 15.93 ms | 0.217 ms |  0.203 ms |  500.0000 |  500.0000 |  500.0000 |      5 MB |
